### PR TITLE
Create .travis.yml to add automated testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+sudo: false
+dist: trusty
+language: python
+python:
+    - 2.7
+    - 3.6.1
+install:
+    - pip install flake8  # pytest  # add some tests later
+before_script:
+    # stop the build if there are Python syntax errors or undefined names
+    - flake8 . --count --select=E901,E999,F821,F822,F823 --statistics
+    # exit-zero treates all errors as warnings.  The GitHub editor is 127 chars wide
+    - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+script: true
+    # pytest --capture=sys    # add some tests later
+notifications:
+    on_success: change
+    on_failure: change  # `always` will be the setting once code changes slow down


### PR DESCRIPTION
This change would enable Travis-CI to automatically run [flake8](http://flake8.readthedocs.io) (and other) tests on every pull request. This will help contributors know if their submissions are going to *break the build*. For Open Source projects, this is a **free** service, but you would need to turn it on.  See https://github.com/marketplace/travis-ci

The current output looks pretty good: https://travis-ci.org/cclauss/flake8_for_InferSent/jobs/251012838#L798 except for `C901 'get_optimizer' is too complex (12)`