### PR TITLE
changed bib in README.md to ACL anthology

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,11 +105,16 @@ Please cite [1](https://arxiv.org/abs/1705.02364) if you found this code useful.
 [1] A. Conneau, D. Kiela, H. Schwenk, L. Barrault, A. Bordes, [*Supervised Learning of Universal Sentence Representations from Natural Language Inference Data*](https://arxiv.org/abs/1705.02364)
 
 ```
-@article{conneau2017supervised,
-  title={Supervised Learning of Universal Sentence Representations from Natural Language Inference Data},
-  author={Conneau, Alexis and Kiela, Douwe and Schwenk, Holger and Barrault, Loic and Bordes, Antoine},
-  journal={arXiv preprint arXiv:1705.02364},
-  year={2017}
+@InProceedings{conneau-EtAl:2017:EMNLP2017,
+  author    = {Conneau, Alexis  and  Kiela, Douwe  and  Schwenk, Holger  and  Barrault, Lo\"{i}c  and  Bordes, Antoine},
+  title     = {Supervised Learning of Universal Sentence Representations from Natural Language Inference Data},
+  booktitle = {Proceedings of the 2017 Conference on Empirical Methods in Natural Language Processing},
+  month     = {September},
+  year      = {2017},
+  address   = {Copenhagen, Denmark},
+  publisher = {Association for Computational Linguistics},
+  pages     = {670--680},
+  url       = {https://www.aclweb.org/anthology/D17-1070}
 }
 ```
 


### PR DESCRIPTION
This might be helpful to others who would like to cite InerSent in settings where *ACL bibs are preferred to arxiv. I am currently preparing an *ACL camera-ready paper so I am converting my bibs from arxiv to acl anthology for those that exist. 

Here's a link to the bibfile from the acl anthology: https://www.aclweb.org/anthology/D/D17/D17-1070.bib