### PR TITLE
extension changed from '.pickle' to .'pkl'

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ for a practical example.** Get started with the following steps:
 
 *0.0) Download our InferSent models (V1 trained with GloVe, V2 trained with fastText)[147MB]:*
 ```bash
-curl -Lo encoder/infersent1.pickle https://dl.fbaipublicfiles.com/infersent/infersent1.pkl
-curl -Lo encoder/infersent2.pickle https://dl.fbaipublicfiles.com/infersent/infersent2.pkl
+curl -Lo encoder/infersent1.pkl https://dl.fbaipublicfiles.com/infersent/infersent1.pkl
+curl -Lo encoder/infersent2.pkl https://dl.fbaipublicfiles.com/infersent/infersent2.pkl
 ```
 Note that infersent1 is trained with GloVe (which have been trained on text preprocessed with the PTB tokenizer) and infersent2 is trained with fastText (which have been trained on text preprocessed with the MOSES tokenizer). The latter also removes the padding of zeros with max-pooling which was inconvenient when embedding sentences outside of their batches.
 


### PR DESCRIPTION
Small typo in the extension of the downloaded pre-trained models, the model should end with '.pkl' instead of '.pickle' (Path not found later otherwise).