### PR TITLE
add explicit encoding for opening w2v to allow code to work on windows

### DIFF
--- a/models.py
+++ b/models.py
@@ -104,7 +104,7 @@ class InferSent(nn.Module):
         assert hasattr(self, 'w2v_path'), 'w2v path not set'
         # create word_vec with w2v vectors
         word_vec = {}
-        with open(self.w2v_path) as f:
+        with open(self.w2v_path, encoding='utf-8') as f:
             for line in f:
                 word, vec = line.split(' ', 1)
                 if word in word_dict:
@@ -117,7 +117,7 @@ class InferSent(nn.Module):
         # create word_vec with k first w2v vectors
         k = 0
         word_vec = {}
-        with open(self.w2v_path) as f:
+        with open(self.w2v_path, encoding='utf-8') as f:
             for line in f:
                 word, vec = line.split(' ', 1)
                 if k <= K:


### PR DESCRIPTION
w2v vectors are encoded in utf-8. When running python 3 on windows (North America), the default encoding used for opening files are 8bit Windows-1252 character set. Reading the w2v file thus throws a decoding error. Setting an encoding will ensure that the w2v vector file can be read. This is also referenced in issue #98.